### PR TITLE
Add building schema validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # CoC-Base-Designer
+
 CoC-Base-Designer
+
+## Building Data Validation
+
+A JSON schema describing the format of `all_buildings_with_ranges.json` is
+provided in [`schema/buildings.schema.json`](schema/buildings.schema.json). You
+can check the file against the schema using the validation script:
+
+```bash
+python3 scripts/validate_buildings.py
+```
+
+The script prints `Validation successful.` when the file conforms to the schema
+and reports any validation errors otherwise.

--- a/schema/buildings.schema.json
+++ b/schema/buildings.schema.json
@@ -1,0 +1,50 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Clash of Clans buildings data",
+  "type": "object",
+  "patternProperties": {
+    ".*": {
+      "oneOf": [
+        {
+          "type": "object",
+          "properties": {
+            "levels": {
+              "type": "array",
+              "items": { "$ref": "#/definitions/level" }
+            },
+            "range": { "type": ["number", "string"] },
+            "range_ground": { "type": ["number", "string"] },
+            "range_air_ground": { "type": ["number", "string"] },
+            "range_max": { "type": ["number", "string"] },
+            "range_min": { "type": ["number", "string"] },
+            "range_single": { "type": ["number", "string"] },
+            "range_multi": { "type": ["number", "string"] }
+          },
+          "required": ["levels"],
+          "additionalProperties": false
+        },
+        {
+          "type": "array",
+          "items": { "$ref": "#/definitions/level" }
+        }
+      ]
+    }
+  },
+  "definitions": {
+    "level": {
+      "type": "object",
+      "properties": {
+        "level": { "type": ["number", "string"] },
+        "dps": { "type": ["number", "string", "null"] },
+        "dph": { "type": ["number", "string", "null"] },
+        "hp": { "type": ["number", "string", "null"] },
+        "cost": { "type": ["number", "string", "null"] },
+        "build_time": { "type": ["number", "string", "null"] },
+        "exp": { "type": ["number", "string", "null"] },
+        "th_required": { "type": ["number", "string", "null"] }
+      },
+      "required": ["level", "dps", "dph", "hp", "cost", "build_time", "exp", "th_required"],
+      "additionalProperties": false
+    }
+  }
+}

--- a/scripts/validate_buildings.py
+++ b/scripts/validate_buildings.py
@@ -1,0 +1,30 @@
+import json
+import sys
+from pathlib import Path
+from jsonschema import Draft7Validator
+
+
+SCHEMA_PATH = Path(__file__).resolve().parents[1] / 'schema' / 'buildings.schema.json'
+DATA_PATH = Path(__file__).resolve().parents[1] / 'all_buildings_with_ranges.json'
+
+
+def main(schema_path: Path = SCHEMA_PATH, data_path: Path = DATA_PATH) -> None:
+    with schema_path.open('r', encoding='utf-8') as f:
+        schema = json.load(f)
+    with data_path.open('r', encoding='utf-8') as f:
+        data = json.load(f)
+
+    validator = Draft7Validator(schema)
+    errors = sorted(validator.iter_errors(data), key=lambda e: list(e.path))
+    if errors:
+        print('Validation failed:')
+        for error in errors:
+            path = '/'.join(str(p) for p in error.path)
+            print(f'- {path}: {error.message}')
+        sys.exit(1)
+
+    print('Validation successful.')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add JSON schema for buildings data
- add Python validation script using `jsonschema`
- document how to validate building data in the README

## Testing
- `python3 scripts/validate_buildings.py`

------
https://chatgpt.com/codex/tasks/task_b_6847d4214d44832380ac79fc84c5f3ca