### PR TITLE
Add React designer scaffold

### DIFF
--- a/designer/.gitignore
+++ b/designer/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+build

--- a/designer/package.json
+++ b/designer/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "designer",
+  "version": "0.1.0",
+  "private": true,
+  "dependencies": {
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0",
+    "react-scripts": "5.0.1",
+    "typescript": "^4.9.5",
+    "konva": "^9.0.0",
+    "react-konva": "^18.0.6"
+  },
+  "scripts": {
+    "start": "react-scripts start",
+    "build": "react-scripts build",
+    "test": "react-scripts test --env=jsdom",
+    "eject": "react-scripts eject"
+  }
+}

--- a/designer/public/index.html
+++ b/designer/public/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Designer</title>
+</head>
+<body>
+  <div id="root"></div>
+</body>
+</html>

--- a/designer/src/App.css
+++ b/designer/src/App.css
@@ -1,0 +1,10 @@
+.sidebar {
+  width: 150px;
+  border-right: 1px solid #ccc;
+  overflow-y: auto;
+}
+
+.inspector {
+  width: 200px;
+  border-left: 1px solid #ccc;
+}

--- a/designer/src/App.tsx
+++ b/designer/src/App.tsx
@@ -1,0 +1,43 @@
+import React, { useState } from 'react';
+import { BuildingsProvider } from './BuildingsContext';
+import Canvas, { BuildingInstance, GhostPlacement } from './Canvas';
+import Sidebar from './Sidebar';
+import Inspector from './Inspector';
+import "./App.css";
+import { Types } from './types';
+
+const TILE_SIZE = 32;
+
+export default function App() {
+  const [items, setItems] = useState<BuildingInstance[]>([]);
+  const [selectedId, setSelectedId] = useState<number | null>(null);
+  const [ghostType, setGhostType] = useState<keyof Types | null>(null);
+  const [ghost, setGhost] = useState<GhostPlacement | null>(null);
+
+  const selected = items.find(i => i.id === selectedId) || null;
+
+  const handleSelectType = (t: keyof Types | null) => {
+    setGhostType(t);
+    setGhost(t ? { type: t, x: 0, y: 0 } : null);
+  };
+
+  return (
+    <BuildingsProvider>
+      <div style={{ display: 'flex', width: '100%' }}>
+        <Sidebar active={ghostType} onSelect={handleSelectType} />
+        <Canvas
+          items={items}
+          setItems={setItems}
+          selectedId={selectedId}
+          setSelectedId={setSelectedId}
+          ghost={ghost}
+          tileSize={TILE_SIZE}
+        />
+        <Inspector
+          building={selected}
+          onChange={b => setItems(prev => prev.map(it => it.id === b.id ? b : it))}
+        />
+      </div>
+    </BuildingsProvider>
+  );
+}

--- a/designer/src/BuildingsContext.tsx
+++ b/designer/src/BuildingsContext.tsx
@@ -1,0 +1,29 @@
+import React, { createContext, useEffect, useState } from 'react';
+import { Types } from './types';
+
+interface Context {
+  buildings: Types | null;
+  setBuildings: React.Dispatch<React.SetStateAction<Types | null>>;
+}
+
+export const BuildingsContext = createContext<Context>({
+  buildings: null,
+  setBuildings: () => {},
+});
+
+export const BuildingsProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [buildings, setBuildings] = useState<Types | null>(null);
+
+  useEffect(() => {
+    fetch('/buildings')
+      .then(res => res.json())
+      .then(data => setBuildings(data))
+      .catch(err => console.error('Failed to fetch buildings', err));
+  }, []);
+
+  return (
+    <BuildingsContext.Provider value={{ buildings, setBuildings }}>
+      {children}
+    </BuildingsContext.Provider>
+  );
+};

--- a/designer/src/Canvas.tsx
+++ b/designer/src/Canvas.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { Stage, Layer, Line, Rect, Group } from 'react-konva';
+import { Types } from './types';
+
+export interface BuildingInstance {
+  id: number;
+  type: keyof Types;
+  x: number;
+  y: number;
+  level: number;
+  rotation: number;
+}
+
+export interface GhostPlacement {
+  type: keyof Types;
+  x: number;
+  y: number;
+}
+
+interface Props {
+  items: BuildingInstance[];
+  setItems: React.Dispatch<React.SetStateAction<BuildingInstance[]>>;
+  selectedId: number | null;
+  setSelectedId: (id: number | null) => void;
+  ghost: GhostPlacement | null;
+  tileSize: number;
+}
+
+const GRID_SIZE = 20;
+
+export default function Canvas({ items, setItems, selectedId, setSelectedId, ghost, tileSize }: Props) {
+  const width = GRID_SIZE * tileSize;
+  const height = GRID_SIZE * tileSize;
+
+  const lines: JSX.Element[] = [];
+  for (let i = 0; i <= GRID_SIZE; i++) {
+    const pos = i * tileSize;
+    lines.push(<Line key={`v${i}`} points={[pos, 0, pos, height]} stroke="#ccc" strokeWidth={1} />);
+    lines.push(<Line key={`h${i}`} points={[0, pos, width, pos]} stroke="#ccc" strokeWidth={1} />);
+  }
+
+  const handleDragEnd = (id: number, e: any) => {
+    const { x, y } = e.target.position();
+    setItems(prev => prev.map(it => it.id === id ? { ...it, x, y } : it));
+  };
+
+  const handleStageClick = (e: any) => {
+    if (ghost) {
+      // place ghost
+      setItems(prev => [...prev, { id: Date.now(), type: ghost.type, x: ghost.x, y: ghost.y, level: 1, rotation: 0 }]);
+    }
+  };
+
+  return (
+    <Stage width={width} height={height} onMouseMove={e => {
+      if (ghost) {
+        ghost.x = Math.floor(e.evt.offsetX / tileSize) * tileSize;
+        ghost.y = Math.floor(e.evt.offsetY / tileSize) * tileSize;
+      }
+    }} onClick={handleStageClick}>
+      <Layer>{lines}</Layer>
+      <Layer>
+        {items.map(b => (
+          <Rect
+            key={b.id}
+            x={b.x}
+            y={b.y}
+            width={tileSize}
+            height={tileSize}
+            fill={b.id === selectedId ? 'orange' : 'lightblue'}
+            rotation={b.rotation}
+            draggable
+            onDragEnd={e => handleDragEnd(b.id, e)}
+            onClick={() => setSelectedId(b.id)}
+          />
+        ))}
+        {ghost && (
+          <Rect
+            x={ghost.x}
+            y={ghost.y}
+            width={tileSize}
+            height={tileSize}
+            fill="rgba(0,0,0,0.3)"
+          />
+        )}
+      </Layer>
+    </Stage>
+  );
+}

--- a/designer/src/Inspector.tsx
+++ b/designer/src/Inspector.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { BuildingInstance } from './Canvas';
+
+interface Props {
+  building: BuildingInstance | null;
+  onChange: (b: BuildingInstance) => void;
+}
+
+export default function Inspector({ building, onChange }: Props) {
+  if (!building) return <div className="inspector">Select a building</div>;
+
+  return (
+    <div className="inspector" style={{ padding: '8px' }}>
+      <div>
+        Level:
+        <input
+          type="range"
+          min={1}
+          max={10}
+          value={building.level}
+          onChange={e => onChange({ ...building, level: parseInt(e.target.value, 10) })}
+        />
+      </div>
+      <div>
+        Rotation:
+        <input
+          type="number"
+          value={building.rotation}
+          onChange={e => onChange({ ...building, rotation: parseInt(e.target.value, 10) })}
+        />
+      </div>
+    </div>
+  );
+}

--- a/designer/src/Sidebar.tsx
+++ b/designer/src/Sidebar.tsx
@@ -1,0 +1,28 @@
+import React, { useContext } from 'react';
+import { BuildingsContext } from './BuildingsContext';
+import { Types } from './types';
+
+interface Props {
+  active: keyof Types | null;
+  onSelect: (t: keyof Types | null) => void;
+}
+
+export default function Sidebar({ active, onSelect }: Props) {
+  const { buildings } = useContext(BuildingsContext);
+  if (!buildings) return <div className="sidebar">Loading...</div>;
+
+  const names = Object.keys(buildings) as Array<keyof Types>;
+  return (
+    <div className="sidebar">
+      {names.map(n => (
+        <div
+          key={n}
+          onClick={() => onSelect(active === n ? null : n)}
+          style={{ padding: '4px', cursor: 'pointer', background: active === n ? '#ddd' : undefined }}
+        >
+          {n}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/designer/src/index.css
+++ b/designer/src/index.css
@@ -1,0 +1,9 @@
+body {
+  margin: 0;
+  font-family: sans-serif;
+}
+
+#root {
+  display: flex;
+  height: 100vh;
+}

--- a/designer/src/index.tsx
+++ b/designer/src/index.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+const root = ReactDOM.createRoot(
+  document.getElementById('root') as HTMLElement
+);
+root.render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/designer/src/types.ts
+++ b/designer/src/types.ts
@@ -1,0 +1,100 @@
+export interface Types {
+    AirDefense:     AirDefense;
+    ArcherTower:    AirDefense;
+    BombTower:      BombTower;
+    BuildersHut:    BuildersHut[];
+    Cannon:         AirDefense;
+    EagleArtillery: EagleArtillery;
+    GiantCannon:    AirDefense;
+    HiddenTesla:    AirDefense;
+    InfernoTower:   InfernoTower;
+    MegaTesla:      AirDefense;
+    Mortar:         Mortar;
+    Scattershot:    Scattershot;
+    WizardTower:    AirDefense;
+    "X-Bow":        XBow;
+}
+
+export interface AirDefense {
+    levels: AirDefenseLevel[];
+    range:  number;
+}
+
+export interface AirDefenseLevel {
+    level:       number;
+    dps:         number;
+    dph:         number;
+    hp:          number;
+    cost:        number;
+    build_time:  string;
+    exp:         number;
+    th_required: number;
+}
+
+export interface BombTower {
+    levels: BombTowerLevel[];
+    range:  number;
+}
+
+export interface BombTowerLevel {
+    level:       number;
+    dps:         number;
+    dph:         number;
+    hp:          number;
+    cost:        number;
+    build_time:  string;
+    exp:         string;
+    th_required: number;
+}
+
+export interface BuildersHut {
+    level:       number;
+    dps:         number | string;
+    dph:         number | string;
+    hp:          number | string;
+    cost:        number | string;
+    build_time:  string;
+    exp:         number | string;
+    th_required: string;
+}
+
+export interface EagleArtillery {
+    levels:    BombTowerLevel[];
+    range_min: number;
+    range_max: number;
+}
+
+export interface InfernoTower {
+    levels:       AirDefenseLevel[];
+    range_single: number;
+    range_multi:  number;
+}
+
+export interface Mortar {
+    levels:    AirDefenseLevel[];
+    range_min: number;
+    range_max: number;
+}
+
+export interface Scattershot {
+    levels:    ScattershotLevel[];
+    range_min: number;
+    range_max: number;
+}
+
+export interface ScattershotLevel {
+    level:       number;
+    dps:         number;
+    dph:         string;
+    hp:          string;
+    cost:        number;
+    build_time:  string;
+    exp:         string;
+    th_required: number;
+}
+
+export interface XBow {
+    levels:           AirDefenseLevel[];
+    range_ground:     number;
+    range_air_ground: number;
+}

--- a/designer/tsconfig.json
+++ b/designer/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "esnext",
+    "moduleResolution": "node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- scaffold a `designer` React app in TypeScript
- fetch `/buildings` with a context provider
- draw a grid and draggable buildings with `react-konva`
- simple sidebar, ghost placement, and inspector panel

## Testing
- `npm test` *(fails: Error: no test specified)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6847d66ad13483238b4bf14bd738cf49